### PR TITLE
grep: set image pull policy

### DIFF
--- a/apps/grep/deployment.yaml
+++ b/apps/grep/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       initContainers:
       - name: repo-seed
         image: bitnami/git:latest
+        imagePullPolicy: Always
         volumeMounts:
         - name: gitrepo
           mountPath: /shared/metacpan_git
@@ -26,6 +27,7 @@ spec:
       containers:
       - name: web
         image: metacpan/metacpan-grep-front-end:latest
+        imagePullPolicy: Always
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
Whenever a new container starts, always pull the image to ensure the latest is always picked.