### PR TITLE
Update quick start docs so we know how to restart/upgrade a container

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -24,3 +24,15 @@ cp ~/git/metacpan-credentials/k8s/hz-mc.kubeconfig ./config
 2. Use the `kubectl apply -k <directory path>` ( e.g. `kubectl apply -k apps/web/hz` ) command to deploy an application
    to a cluster. Use the appropriate directory structure to deploy the
    application to the intended environment.
+
+## Connecting to containers
+
+1. Run `k9s`
+2. Find container
+3. Click `s` to get a shell!
+
+## Restarting (to upgrade to latest image)
+
+Connect, as above
+
+NOTE: you can use `killall5` which will kill off the container and then if `imagePullPolicy: Always` is set it will pull the image and start a new container from there.


### PR DESCRIPTION
I did have `kubectl` instructions but this is quicker and better for a quick start doc