### PR TITLE
fix: check if directory exists before cloning

### DIFF
--- a/apps/grep/base/deployment.yaml
+++ b/apps/grep/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         volumeMounts:
         - name: gitrepo
           mountPath: /shared/metacpan_git
-        command: ['sh', '-c', 'git clone https://github.com/metacpan/metacpan-cpan-extracted.git /shared/metacpan_git']
+        command: ['sh', '-c', '[ -d /shared/metacpan_git/.git ] || git clone https://github.com/metacpan/metacpan-cpan-extracted.git /shared/metacpan_git']
       containers:
       - name: web
         image: metacpan/metacpan-grep-front-end:latest


### PR DESCRIPTION
With persistent storage, the clone doesn't have to happen every time the container starts up. This change adds a check to make sure the clone doesn't exist before proceeding.

The update process that runs later will take care of keeping the clone up to date.