### PR TITLE
Ssoriche/arrange

### DIFF
--- a/apps/grep/environments/prod/kustomization.yaml
+++ b/apps/grep/environments/prod/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../environments/prod/
+  - ../../manifests/
+  - ../../base/

--- a/apps/grep/hz/kustomization.yaml
+++ b/apps/grep/hz/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./project.yaml
+  - ./prod_application.yaml
   - ../environments/prod/

--- a/apps/grep/hz/kustomization.yaml
+++ b/apps/grep/hz/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./project.yaml
   - ../environments/prod/

--- a/apps/grep/hz/prod_application.yaml
+++ b/apps/grep/hz/prod_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps--grep
+  namespace: argocd
+spec:
+  project: grep
+  source:
+    repoURL: https://github.com/metacpan/metacpan-k8s
+    targetRevision: HEAD
+    path: apps/grep/environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps--grep

--- a/apps/grep/hz/project.yaml
+++ b/apps/grep/hz/project.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: grep
+  namespace: argocd
+spec:
+  # Project description
+  description: Grep MetaCPAN
+
+  sourceRepos:
+  - '*'
+
+  destinations:
+    - namespace: apps--grep
+      server: https://kubernetes.default.svc
+      name: in-cluster

--- a/apps/web/environments/prod/kustomization.yaml
+++ b/apps/web/environments/prod/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/
+images:
+- name: metacpan/metacpan-web
+  newTag: 0041bd0c0d3dbf0b3d51671f1d7a580fcffa4d7d

--- a/apps/web/environments/stage/kustomization.yaml
+++ b/apps/web/environments/stage/kustomization.yaml
@@ -1,40 +1,39 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: stage--apps--web
 resources:
-  - ../../base/
+- ../../base/
 images:
-  - name: metacpan/metacpan-web
-    newTag: 6796747a21beb1feeed5bb7cc8f52b581299c918
+- name: metacpan/metacpan-web
+  newTag: 6796747a21beb1feeed5bb7cc8f52b581299c918
 patchesStrategicMerge:
-  - |-
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: web
-      namespace: apps--web
-    spec:
-      tls:
-        - hosts:
-          - web.stage.hz.metacpan.org
-          - www.stage.metacpan.org
-          - stage.metacpan.org
-          secretName: web-tls
+- |-
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: web
+    namespace: apps--web
+  spec:
+    tls:
+      - hosts:
+        - web.stage.hz.metacpan.org
+        - www.stage.metacpan.org
+        - stage.metacpan.org
+        secretName: web-tls
 patches:
-  - patch: |-
-      - op: replace
-        path: /spec/rules/0/host
-        value: web.stage.hz.metacpan.org
-      - op: replace
-        path: /spec/rules/1/host
-        value: www.stage.hz.metacpan.org
-      - op: replace
-        path: /spec/rules/2/host
-        value: stage.hz.metacpan.org
-    target:
-      group: networking.k8s.io
-      version: v1
-      kind: Ingress
-      name: web
-      namespace: apps--web
+- patch: |-
+    - op: replace
+      path: /spec/rules/0/host
+      value: web.stage.hz.metacpan.org
+    - op: replace
+      path: /spec/rules/1/host
+      value: www.stage.hz.metacpan.org
+    - op: replace
+      path: /spec/rules/2/host
+      value: stage.hz.metacpan.org
+  target:
+    group: networking.k8s.io
+    kind: Ingress
+    name: web
+    namespace: apps--web
+    version: v1

--- a/apps/web/hz/kustomization.yaml
+++ b/apps/web/hz/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./project.yaml
   - ./stage_sealedsecret.yaml
   - ./prod_sealedsecret.yaml
   - ../environments/stage/

--- a/apps/web/hz/kustomization.yaml
+++ b/apps/web/hz/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ./project.yaml
   - ./stage_sealedsecret.yaml
+  - ./stage_application.yaml
   - ./prod_sealedsecret.yaml
+  - ./prod_application.yaml
   - ../environments/stage/
   - ../environments/prod/

--- a/apps/web/hz/prod_application.yaml
+++ b/apps/web/hz/prod_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps--web
+  namespace: argocd
+spec:
+  project: web
+  source:
+    repoURL: https://github.com/metacpan/metacpan-k8s
+    targetRevision: HEAD
+    path: apps/web/environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps--web

--- a/apps/web/hz/project.yaml
+++ b/apps/web/hz/project.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: web
+  namespace: argocd
+spec:
+  # Project description
+  description: MetaCPAN Web UI
+
+  sourceRepos:
+  - '*'
+
+  destinations:
+    - namespace: apps--web
+      server: https://kubernetes.default.svc
+      name: in-cluster

--- a/apps/web/hz/stage_application.yaml
+++ b/apps/web/hz/stage_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stage--apps--web
+  namespace: argocd
+spec:
+  project: web
+  source:
+    repoURL: https://github.com/metacpan/metacpan-k8s
+    targetRevision: HEAD
+    path: apps/web/environments/stage
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: stage--apps--web

--- a/apps/web/manifests/kustomization.yaml
+++ b/apps/web/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./project.yaml

--- a/platform/argocd/patches/kustomization.yaml
+++ b/platform/argocd/patches/kustomization.yaml
@@ -40,3 +40,28 @@ patchesStrategicMerge:
                 teams:
                   - ADMINS
               loadAllGroups: false
+  - |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-rbac-cm
+        app.kubernetes.io/part-of: argocd
+      name: argocd-rbac-cm
+    data:
+      policy.csv: |
+        p, role:org-admin, applications, *, */*, allow
+        p, role:org-admin, clusters, get, *, allow
+        p, role:org-admin, repositories, get, *, allow
+        p, role:org-admin, repositories, create, *, allow
+        p, role:org-admin, repositories, update, *, allow
+        p, role:org-admin, repositories, delete, *, allow
+        p, role:org-admin, projects, get, *, allow
+        p, role:org-admin, projects, create, *, allow
+        p, role:org-admin, projects, update, *, allow
+        p, role:org-admin, projects, delete, *, allow
+        p, role:org-admin, logs, get, *, allow
+        p, role:org-admin, exec, create, */*, allow
+
+        g, metacpan:ADMINS, role:org-admin
+      policy.default: role:readonly


### PR DESCRIPTION
This PR adds authorization for members of the metacpan organization's ADMINS group to view applications defined to ArgoCD.

Added the ArgoCD AppProject, and Application manifests for the apps/web, and apps/grep applications. These definitions allow the ArgoCD application to watch the metacpan-k8s manifest and automatically apply changes to the clusters.