### PR TITLE
fix(grep): removing manifests directory processing

### DIFF
--- a/apps/grep/environments/prod/kustomization.yaml
+++ b/apps/grep/environments/prod/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../manifests/
   - ../../base/


### PR DESCRIPTION
A hold over from an earlier implementation, removing as the directory no longer exists.