### PR TITLE
Make ArgoCD Sync Happy

### DIFF
--- a/apps/grep/hz/prod_application.yaml
+++ b/apps/grep/hz/prod_application.yaml
@@ -7,7 +7,7 @@ spec:
   project: grep
   source:
     repoURL: https://github.com/metacpan/metacpan-k8s
-    targetRevision: HEAD
+    targetRevision: main
     path: apps/grep/environments/prod
   destination:
     server: https://kubernetes.default.svc

--- a/apps/grep/hz/project.yaml
+++ b/apps/grep/hz/project.yaml
@@ -10,6 +10,10 @@ spec:
   sourceRepos:
   - '*'
 
+  clusterResourceWhitelist:
+    - group: ''
+      kind: 'Namespace'
+
   destinations:
     - namespace: apps--grep
       server: https://kubernetes.default.svc

--- a/apps/web/hz/prod_application.yaml
+++ b/apps/web/hz/prod_application.yaml
@@ -7,7 +7,7 @@ spec:
   project: web
   source:
     repoURL: https://github.com/metacpan/metacpan-k8s
-    targetRevision: HEAD
+    targetRevision: main
     path: apps/web/environments/prod
   destination:
     server: https://kubernetes.default.svc

--- a/apps/web/hz/project.yaml
+++ b/apps/web/hz/project.yaml
@@ -10,6 +10,10 @@ spec:
   sourceRepos:
   - '*'
 
+  clusterResourceWhitelist:
+    - group: ''
+      kind: 'Namespace'
+
   destinations:
     - namespace: apps--web
       server: https://kubernetes.default.svc

--- a/apps/web/hz/stage_application.yaml
+++ b/apps/web/hz/stage_application.yaml
@@ -7,7 +7,7 @@ spec:
   project: web
   source:
     repoURL: https://github.com/metacpan/metacpan-k8s
-    targetRevision: HEAD
+    targetRevision: main
     path: apps/web/environments/stage
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
In order for sync not to error due to the namespace, allow ArgoCD to manage the application namespaces.