### PR TITLE
fix dumb-init

### DIFF
--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -20,8 +20,18 @@ spec:
         - name: web
           image: metacpan/metacpan-web:latest
           imagePullPolicy: Always
-          command: ["plackup"]
-          args: ["--port", "5001", "-E", "production", "-s", "Gazelle"]
+          command: ["/usr/bin/dumb-init"]
+          args:
+            [
+              "--",
+              "/usr/local/bin/plackup",
+              "--port",
+              "5001",
+              "-E",
+              "production",
+              "-s",
+              "Gazelle",
+            ]
           ports:
             - containerPort: 5001
           volumeMounts:


### PR DESCRIPTION
While the container has an entrypoint defined the k8s command overrides that setting. Updating the manifests to do what the entrypoint intended.