### PR TITLE
Configure uwsgi to use less resources

### DIFF
--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -27,7 +27,13 @@ spec:
             - name: metacpan-web-local
               mountPath: /metacpan-web/metacpan_web_local.conf
               subPath: metacpan_web_local.conf
+            - name: uwsgi
+              mountPath: /etc/uwsgi.ini
+              subPath: uwsgi.ini
       volumes:
         - name: metacpan-web-local
           secret:
             secretName: metacpan-web-local
+        - name: uwsgi
+          configMap:
+            name: uwsgi

--- a/apps/web/environments/prod/configmap-uwsgi.yaml
+++ b/apps/web/environments/prod/configmap-uwsgi.yaml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+metadata:
+  name: uwsgi
+  namespace: apps--web
+apiVersion: v1
+data:
+  uwsgi.ini: |
+    [uwsgi]
+    master = true
+    workers = 5
+    die-on-term = true
+
+    disable-logging = true
+
+    listen = 1024
+    post-buffering = 4096
+    buffer-size = 65535
+
+    early-psgi = true
+    perl-no-die-catch = true

--- a/apps/web/environments/prod/kustomization.yaml
+++ b/apps/web/environments/prod/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 - prod_sealedsecret.yaml
 - namespace.yaml
 - ingress.yaml
+- configmap-uwsgi.yaml
 - ../../base/


### PR DESCRIPTION
The current settings for uwsgi are using all the resources available to the nodes. 

Converting the configuration from a file contained in the base image, into a kubernetes ConfigMap to allow us to change the configuration without rebuilding images, and reduce the number of workers from 20 to 5.