### PR TITLE
fix quoting in set-image commit

### DIFF
--- a/.github/workflows/set-image.yml
+++ b/.github/workflows/set-image.yml
@@ -52,6 +52,6 @@ jobs:
         run: |
           kustomize edit set image ${{ inputs.base-tag }} ${{ inputs.tag }}
           git add .
-          git commit -m "Update ${{ inputs.app }} to `${{ inputs.tag }}`"
+          git commit -m 'Update ${{ inputs.app }} to `${{ inputs.tag }}`'
       - name: Push manifests
         run: git push


### PR DESCRIPTION
Using double quotes means backquotes are interpolated as a shell command.