### PR TITLE
less workers for api v0 shim

### DIFF
--- a/apps/api-v0-shim/base/deployment.yaml
+++ b/apps/api-v0-shim/base/deployment.yaml
@@ -19,5 +19,7 @@ spec:
       - name: api-v0-shim
         image: metacpan/metacpan-api-v0-shim:latest
         imagePullPolicy: Always
+        command: [ "/uwsgi.sh" ]
+        args: [ "--http-socket", ":5001", "--workers", "5" ]
         ports:
         - containerPort: 5001


### PR DESCRIPTION
The v0 API shim has very low traffic. Use less workers to reduce its memory usage.