### PR TITLE
Initial test-smoke

### DIFF
--- a/apps/test-smoke/README.md
+++ b/apps/test-smoke/README.md
@@ -1,0 +1,1 @@
+Deploy `argo` and that will then deploy the environments

--- a/apps/test-smoke/argo/kustomization.yaml
+++ b/apps/test-smoke/argo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./project.yaml
+  - ./prod_application.yaml

--- a/apps/test-smoke/argo/prod_application.yaml
+++ b/apps/test-smoke/argo/prod_application.yaml
@@ -7,7 +7,7 @@ spec:
   project: testsmoke
   source:
     repoURL: https://github.com/metacpan/metacpan-k8s
-    targetRevision: leo/testsmoke
+    targetRevision: main
     path: apps/test-smoke/environments/prod
   destination:
     server: https://kubernetes.default.svc

--- a/apps/test-smoke/argo/prod_application.yaml
+++ b/apps/test-smoke/argo/prod_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps--testsmoke
+  namespace: argocd
+spec:
+  project: testsmoke
+  source:
+    repoURL: https://github.com/metacpan/metacpan-k8s
+    targetRevision: leo/testsmoke
+    path: apps/test-smoke/environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: apps--testsmoke

--- a/apps/test-smoke/argo/project.yaml
+++ b/apps/test-smoke/argo/project.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: testsmoke
+  namespace: argocd
+spec:
+  # Project description
+  description: Test Smoke
+
+  sourceRepos:
+  - '*'
+
+  clusterResourceWhitelist:
+    - group: ''
+      kind: 'Namespace'
+
+  destinations:
+    - namespace: apps--testsmoke
+      server: https://kubernetes.default.svc
+      name: in-cluster

--- a/apps/test-smoke/base/deployment.yaml
+++ b/apps/test-smoke/base/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testsmoke-web
+  labels:
+    app: testsmoke-web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: testsmoke-web
+  template:
+    metadata:
+      labels:
+        app: testsmoke-web
+    spec:
+      containers:
+        - name: web
+          image: metacpan/perl5-coresmokedb-web:latest
+          imagePullPolicy: Always
+          # command: [ "/uwsgi.sh" ]
+          # args: [ "--http-socket", ":5001" ]
+          ports:
+            - containerPort: 5555
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testsmoke-api
+  labels:
+    app: testsmoke-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: testsmoke-api
+  template:
+    metadata:
+      labels:
+        app: testsmoke-api
+    spec:
+      containers:
+        - name: web
+          image: metacpan/perl5-coresmokedb-api:latest
+          imagePullPolicy: Always
+          # command: [ "/uwsgi.sh" ]
+          # args: [ "--http-socket", ":5001" ]
+          ports:
+            - containerPort: 5555
+        - name: api
+          image: metacpan/perl5-coresmokedb-api:latest
+          imagePullPolicy: Always
+          # command: [ "/uwsgi.sh" ]
+          # args: [ "--http-socket", ":5001" ]
+          ports:
+            - containerPort: 5050

--- a/apps/test-smoke/base/kustomization.yaml
+++ b/apps/test-smoke/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/apps/test-smoke/base/service.yaml
+++ b/apps/test-smoke/base/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: testsmoke-web
+spec:
+  ports:
+    - port: 80
+      targetPort: 5555
+  selector:
+    app: web
+---
+apiVersion: v1    
+kind: Service
+metadata:
+  name: testsmoke-api
+spec:
+  ports:
+    - port: 80
+      targetPort: 5050
+  selector:
+    app: api

--- a/apps/test-smoke/environments/prod/ingress.yaml
+++ b/apps/test-smoke/environments/prod/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: testsmoke
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - testsmoke-web.do.metacpan.org
+        - testsmoke-api.do.metacpan.org
+      secretName: web-tls
+  rules:
+    - host: testsmoke-web.do.metacpan.org
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: web
+                port:
+                  number: 80
+    - host: testsmoke-api.metacpan.org
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: api
+                port:
+                  number: 80
+

--- a/apps/test-smoke/environments/prod/kustomization.yaml
+++ b/apps/test-smoke/environments/prod/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps--testsmoke
+images:
+- name: metacpan/metacpan-web
+  newTag: sha-7e3035cd0a9729fef34911f3246632b52b6df76d
+resources:
+- namespace.yaml
+- ingress.yaml
+- ../../base/

--- a/apps/test-smoke/environments/prod/namespace.yaml
+++ b/apps/test-smoke/environments/prod/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps--testsmoke


### PR DESCRIPTION
For #99

https://testsmoke-web.do.metacpan.org/ - nice 503
https://testsmoke-api.do.metacpan.org/ - good 'old 404

BUT..
- No DB setup ( can see DBIx errors in the container log for testsmoke-api ) [DB Details](https://github.com/metacpan/Perl5-CoreSmokeDB-API/blob/494c67dd78ad41e3cd353cad245375dca100d3ca/README.md?plain=1#L100-L115)
- Not sure web is running what ever init commands are needed ( see error log in container )

Todo:
- DO Postgres user and getting creds into the API container - using https://docs.digitalocean.com/products/kubernetes/how-to/use-operator/ (Managed Database Architecture) - [K8 docs to setup user/credetials](https://github.com/digitalocean/do-operator/tree/main/docs/databases#managed-database-architecture)
- Fix web start up
- Remove `targetRevision: leo/testsmoke` from apps/test-smoke/argo/prod_application.yaml when ready to go live

Applying for testing and you can then push this branch and use the Argo UI to refresh containers
```
kubectl apply -k apps/test-smoke/argo
```
