### PR TITLE
More random trial and error

### DIFF
--- a/apps/test-smoke/base/deployment.yaml
+++ b/apps/test-smoke/base/deployment.yaml
@@ -41,13 +41,6 @@ spec:
         app: testsmoke-api
     spec:
       containers:
-        - name: web
-          image: metacpan/perl5-coresmokedb-api:latest
-          imagePullPolicy: Always
-          # command: [ "/uwsgi.sh" ]
-          # args: [ "--http-socket", ":5001" ]
-          ports:
-            - containerPort: 5555
         - name: api
           image: metacpan/perl5-coresmokedb-api:latest
           imagePullPolicy: Always

--- a/apps/test-smoke/base/service.yaml
+++ b/apps/test-smoke/base/service.yaml
@@ -7,7 +7,7 @@ spec:
     - port: 80
       targetPort: 5555
   selector:
-    app: web
+    app: testsmoke-web
 ---
 apiVersion: v1    
 kind: Service
@@ -18,4 +18,4 @@ spec:
     - port: 80
       targetPort: 5050
   selector:
-    app: api
+    app: testsmoke-api

--- a/apps/test-smoke/environments/prod/ingress.yaml
+++ b/apps/test-smoke/environments/prod/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: testsmoke
+  name: testsmoke-web
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
 spec:
@@ -9,7 +9,6 @@ spec:
   tls:
     - hosts:
         - testsmoke-web.do.metacpan.org
-        - testsmoke-api.do.metacpan.org
       secretName: web-tls
   rules:
     - host: testsmoke-web.do.metacpan.org
@@ -19,17 +18,31 @@ spec:
             path: "/"
             backend:
               service:
-                name: web
+                name: testsmoke-web
                 port:
                   number: 80
-    - host: testsmoke-api.metacpan.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: testsmoke-api
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - testsmoke-api.do.metacpan.org
+      secretName: api-tls
+  rules:
+    - host: testsmoke-api.do.metacpan.org
       http:
         paths:
           - pathType: Prefix
             path: "/"
             backend:
               service:
-                name: api
+                name: testsmoke-api
                 port:
                   number: 80
 


### PR DESCRIPTION
https://testsmoke-web.do.metacpan.org/ - now looks right

`curl -k https://testsmoke-api.do.metacpan.org/api/version` does a 404 (also don't know why)


NOTE: Once this is merged will need to update the [Argo UI](https://argocd.do.metacpan.org/applications/argocd/apps--testsmoke?view=tree&resource=&node=argoproj.io%2FApplication%2Fargocd%2Fapps--testsmoke%2F0) and switch the `TARGET REVISION` back to `main`