### PR TITLE
Rolling Updates

### DIFF
--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app: web
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   replicas: 3
   selector:
     matchLabels:


### PR DESCRIPTION
Set the deployment strategy to have 1 pod unavailable during deployments
of updates. This is to reduce the 503 errors reported by Fastly during
the deployment of a new version.
