### PR TITLE
conf(web): Add startup and liveness probes to web deployment

### DIFF
--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -37,6 +37,18 @@ spec:
             - name: metacpan-web-local
               mountPath: /app/metacpan_web_local.conf
               subPath: metacpan_web_local.conf
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 5001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: 5001
+            failureThreshold: 30
+            periodSeconds: 10
       volumes:
         - name: metacpan-web-local
           secret:


### PR DESCRIPTION
These probes ensure the application is running and able to process
traffic, and remains healthy to continue to route traffic to. This
allows the cluster tooling to manage the ingress/load balancer and
deliver traffic to pods that are able to handle data.
