### PR TITLE
Adding a proxy in front of web

### DIFF
--- a/apps/web/base/configmap.yaml
+++ b/apps/web/base/configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: caddy-config
+data:
+  Caddyfile: |
+    {
+      admin :2019
+      metrics
+    }
+    :80 {
+      reverse_proxy localhost:5001
+    }

--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           image: metacpan/metacpan-web:latest
           imagePullPolicy: Always
           command: ["/uwsgi.sh"]
-          args: ["--http-socket", ":5001"]
+          args: ["--http-socket", ":5001", "--workers", "10"]
           ports:
             - containerPort: 5001
           resources:

--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         - name: web
           image: metacpan/metacpan-web:latest
           imagePullPolicy: Always
-          command: [ "/uwsgi.sh" ]
-          args: [ "--http-socket", ":5001" ]
+          command: ["/uwsgi.sh"]
+          args: ["--http-socket", ":5001"]
           ports:
             - containerPort: 5001
           resources:
@@ -37,7 +37,25 @@ spec:
             - name: metacpan-web-local
               mountPath: /app/metacpan_web_local.conf
               subPath: metacpan_web_local.conf
+        - name: caddy
+          image: caddy:latest
+          ports:
+            - containerPort: 2019
+            - containerPort: 80
+          volumeMounts:
+            - name: caddy-config
+              mountPath: /etc/caddy
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
       volumes:
         - name: metacpan-web-local
           secret:
             secretName: metacpan-web-local
+        - name: caddy-config
+          configMap:
+            name: caddy-config

--- a/apps/web/base/kustomization.yaml
+++ b/apps/web/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./configmap.yaml
+  - ./servicemonitor.yaml

--- a/apps/web/base/kustomization.yaml
+++ b/apps/web/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./deployment.yaml
   - ./service.yaml
+  - ./configmap.yaml

--- a/apps/web/base/service.yaml
+++ b/apps/web/base/service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: 5001
+      targetPort: 80
   selector:
     app: web
 ---

--- a/apps/web/base/service.yaml
+++ b/apps/web/base/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,5 +7,22 @@ spec:
   ports:
     - port: 80
       targetPort: 5001
+  selector:
+    app: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-metrics
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/name: web-metrics
+    app.kubernetes.io/part-of: web
+spec:
+  ports:
+    - name: metrics
+      port: 2019
+      targetPort: 2019
+      protocol: TCP
   selector:
     app: web

--- a/apps/web/base/servicemonitor.yaml
+++ b/apps/web/base/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: http-metrics
+  namespace: apps--web
+  labels:
+    app: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web-metrics
+  namespaceSelector:
+    matchNames:
+      - apps--web
+  endpoints:
+    - port: metrics
+      interval: 15s


### PR DESCRIPTION
Using caddy as a reverse proxy in a sidecar container to handle connections.

Caddy provides metrics about the number of requests and the responses it is returning.

Also lowered the number of workers for the perl web server, the proxy should provide some offloading and allow for less workers, which has reduced the amount of memory the container is using.