### PR TITLE
Fix kube-prometheus path

### DIFF
--- a/platform/kube-prometheus/do/application.yaml
+++ b/platform/kube-prometheus/do/application.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/metacpan/metacpan-k8s
     targetRevision: main
-    path: prometheus/kube-prometheus/do
+    path: platform/kube-prometheus/do
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring


### PR DESCRIPTION
I'm going to blame autocomplete in the editor for this one. The path was
never prometheus/ so that's the only explanation for it being there.
