### PR TITLE
Upgrade kube-prometheus and thanos sidecar

### DIFF
--- a/platform/kube-prometheus/base/prometheus-operator-prometheusRule.yaml
+++ b/platform/kube-prometheus/base/prometheus-operator-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
     prometheus: k8s
     role: alert-rules
   name: prometheus-operator-rules

--- a/platform/kube-prometheus/base/prometheus-operator-serviceMonitor.yaml
+++ b/platform/kube-prometheus/base/prometheus-operator-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -21,4 +21,4 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/name: prometheus-operator
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 0.80.1
+      app.kubernetes.io/version: 0.81.0

--- a/platform/kube-prometheus/base/prometheus-prometheus.yaml
+++ b/platform/kube-prometheus/base/prometheus-prometheus.yaml
@@ -61,9 +61,9 @@ spec:
             storage: 10Gi
         storageClassName: do-block-storage
   thanos:
-    image: quay.io/thanos/thanos:v0.36.1
+    image: quay.io/thanos/thanos:v0.30.0
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objectstorage
-    version: 0.36.1
+    version: 0.38.0
   version: 3.2.1

--- a/platform/kube-prometheus/base/setup/prometheus-operator-clusterRole.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
 rules:
 - apiGroups:

--- a/platform/kube-prometheus/base/setup/prometheus-operator-clusterRoleBinding.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/platform/kube-prometheus/base/setup/prometheus-operator-deployment.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
   namespace: monitoring
 spec:
@@ -23,17 +23,17 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: prometheus-operator
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 0.80.1
+        app.kubernetes.io/version: 0.81.0
     spec:
       automountServiceAccountToken: true
       containers:
       - args:
         - --kubelet-service=kube-system/kubelet
-        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
+        - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
         env:
         - name: GOGC
           value: "30"
-        image: quay.io/prometheus-operator/prometheus-operator:v0.80.1
+        image: quay.io/prometheus-operator/prometheus-operator:v0.81.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/platform/kube-prometheus/base/setup/prometheus-operator-networkPolicy.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-networkPolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
   namespace: monitoring
 spec:

--- a/platform/kube-prometheus/base/setup/prometheus-operator-service.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
   namespace: monitoring
 spec:

--- a/platform/kube-prometheus/base/setup/prometheus-operator-serviceAccount.yaml
+++ b/platform/kube-prometheus/base/setup/prometheus-operator-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.80.1
+    app.kubernetes.io/version: 0.81.0
   name: prometheus-operator
   namespace: monitoring

--- a/platform/kube-prometheus/jsonnetfile.lock.json
+++ b/platform/kube-prometheus/jsonnetfile.lock.json
@@ -148,8 +148,8 @@
           "subdir": "jsonnet/kube-prometheus"
         }
       },
-      "version": "0a5bf85a28216f08e7ce1bfa3ae39adc0f063857",
-      "sum": "ZvcpiSsF4gbeW8m5hNqOBjO1Io0wpKErzjQ3qyXPsO0="
+      "version": "685008710cbb881cd8fce9db1e2f890c9e249903",
+      "sum": "mtF0Ngi8FRb5GkhxT0h7yyQMXkWXqdz+0Vy9RYHejRY="
     },
     {
       "source": {

--- a/platform/kube-prometheus/settings.jsonnet
+++ b/platform/kube-prometheus/settings.jsonnet
@@ -17,8 +17,8 @@ local kp =
       },
       prometheus+: {
         thanos: {
-          version: '0.36.1',
-          image: 'quay.io/thanos/thanos:v0.36.1',
+          version: '0.38.0',
+          image: 'quay.io/thanos/thanos:v0.30.0',
           objectStorageConfig: {
             key: 'thanos.yaml',  // How the file inside the secret is called
             name: 'thanos-objectstorage',  // This is the name of your Kubernetes secret with the config


### PR DESCRIPTION
Upgrading kube-prometheus and the thanos sidecar, the previous versions
were incompatible resulting in loss of metrics. The previous version of
thanos didn't support PrometheusText as a protocol.
