### PR TITLE
Leo/backpan syncer

### DIFF
--- a/apps/backpan-syncer/argo/kustomization.yaml
+++ b/apps/backpan-syncer/argo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./project.yaml
+  - ./prod_application.yaml

--- a/apps/backpan-syncer/argo/prod_application.yaml
+++ b/apps/backpan-syncer/argo/prod_application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name:  apps--backpan-syncer
+  namespace: argocd
+spec:
+  project: backpan-syncer
+  source:
+    repoURL: https://github.com/metacpan/metacpan-k8s
+    targetRevision: main
+    path: apps/backpan-syncer/environments/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace:  apps--backpan-syncer

--- a/apps/backpan-syncer/argo/project.yaml
+++ b/apps/backpan-syncer/argo/project.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: backpan-syncer
+  namespace: argocd
+spec:
+  # Project description
+  description: Syncing of BackPan + CPAN.org updates to B2
+
+  sourceRepos:
+  - '*'
+
+  clusterResourceWhitelist:
+    - group: ''
+      kind: 'Namespace'
+
+  destinations:
+    - namespace: apps--backpan-syncer
+      server: https://kubernetes.default.svc
+      name: in-cluster

--- a/apps/backpan-syncer/base/deployment.yaml
+++ b/apps/backpan-syncer/base/deployment.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backpan-syncer
+  labels:
+    app: backpan-syncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backpan-syncer
+  template:
+    metadata:
+      labels:
+        app: backpan-syncer
+    spec:
+      containers:
+        - name: backpan-syncer
+          image: metacpan/metacpan-backpan-syncer:latest
+          imagePullPolicy: Always
+          # Should change to /sbin/run.sh once data is sorted
+          command: ["sh"]
+          args:
+            - "-c"
+            - "/usr/bin/sleep infinity"
+          # This container needs to use fuse so needs privileges
+          securityContext:
+            privileged: true

--- a/apps/backpan-syncer/base/deployment.yaml
+++ b/apps/backpan-syncer/base/deployment.yaml
@@ -27,3 +27,15 @@ spec:
           # This container needs to use fuse so needs privileges
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: backpan
+              mountPath: /mnt/backpan
+            - name: b2-backpan-cache
+              mountPath: /mnt/b2-backpan-cache
+      volumes:
+        - name: backpan
+          persistentVolumeClaim:
+            claimName: backpan
+        - name: b2-backpan-cache
+          persistentVolumeClaim:
+            claimName: b2-backpan-cache

--- a/apps/backpan-syncer/base/deployment.yaml
+++ b/apps/backpan-syncer/base/deployment.yaml
@@ -32,6 +32,9 @@ spec:
               mountPath: /mnt/backpan
             - name: b2-backpan-cache
               mountPath: /mnt/b2-backpan-cache
+            - name: rclone-conf
+              mountPath: /root/.config/rclone/rclone.conf
+              subPath: rclone-conf
       volumes:
         - name: backpan
           persistentVolumeClaim:
@@ -39,3 +42,6 @@ spec:
         - name: b2-backpan-cache
           persistentVolumeClaim:
             claimName: b2-backpan-cache
+        - name: rclone-conf
+          secret:
+            secretName: rclone-conf

--- a/apps/backpan-syncer/base/kustomization.yaml
+++ b/apps/backpan-syncer/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./deployment.yaml
+  - ./pvc.yaml

--- a/apps/backpan-syncer/base/kustomization.yaml
+++ b/apps/backpan-syncer/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml

--- a/apps/backpan-syncer/base/pvc.yaml
+++ b/apps/backpan-syncer/base/pvc.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backpan
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: do-block-storage
+  resources:
+    requests:
+      storage: 160Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: b2-backpan-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: do-block-storage
+  resources:
+    requests:
+      storage: 40Gi

--- a/apps/backpan-syncer/environments/prod/kustomization.yaml
+++ b/apps/backpan-syncer/environments/prod/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: apps--backpan-syncer
 resources:
 - namespace.yaml
+- rclone-conf-sealedsecret.yaml
 - ../../base/
 images:
 - name: metacpan/metacpan-backpan-syncer

--- a/apps/backpan-syncer/environments/prod/kustomization.yaml
+++ b/apps/backpan-syncer/environments/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps--backpan-syncer
+resources:
+- namespace.yaml
+- ../../base/
+images:
+- name: metacpan/metacpan-backpan-syncer
+  newTag: latest

--- a/apps/backpan-syncer/environments/prod/namespace.yaml
+++ b/apps/backpan-syncer/environments/prod/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apps--backpan-syncer

--- a/apps/backpan-syncer/environments/prod/rclone-conf-sealedsecret.yaml
+++ b/apps/backpan-syncer/environments/prod/rclone-conf-sealedsecret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: rclone-conf
+  namespace: apps--backpan-syncer
+spec:
+  encryptedData:
+    rclone-conf: AgB68GCeQpNx2m7OukR7lB2OZxPkIdQO68y2sxjKAtwFIbv8nwnwbdDjOWeDOmKfCmy3BTYKF8BlXArmiAcvHiPr2cMdOu0VWhsUy9VdMI8Ot6YZXOXhin4PeljCqPbqNaz9USzKFsXIWjj89mq5F42qfggoUFbZL8Jp0xpNg+a9ym/qEt85jhVviDcXSzZdTKO98G2tmMMuh6oFhpFLS7h95CUCvb9t2HZm478V5ygVxf/NfbJ0cTjBhAs9rhgoTYgII8wH6k4JP9W3nG9ixm4V9z8Jmo+KqBdyE5hw/3W57PGzEQCJUbWDPxDtdayltm3QoUtzf6hZ+1Jm47qb8q0Ia0AuS0RmsCz+ZZsRU5o9KIaFbjCWLDijnOKBiG/+1pAOzv6du2MVaFTbpxKyjUro7IQLk37efu6OQHJNURc43jD0/r6Jj/yzKnTUiowMLdepOBmaZlWTyt/20VS6vhsc6cR8KxPUNCz9NlJiLexwWNTZzdNl6FecmCyEFAqtAirGYoE+6lkPO7pxqzChitW3BL5aVutRrcmzLoIU52EmZwELIagVSoYJasrcZtWFQ7ei/2IfgRlD8YjF1M4cz/+urglgJXk0SQLA5rUKBfjkR1cGYAbrkZr8FrRTrLUrUzRX8RHmEeEWWJeKAUcHn89yd1lpf6ewxjvgIj6T0frbXRmy6tuSsOgl9vElynXARu+ZhOOTqXFN5jDlkMyBjbYcF/QsCZsx5GRAAt8FjzYFD81fngo22c8c6R5ABIuqOVjL7r+faq79CDcyVBYuacJinVQNVTJg8TeGWLukwV4tYaRqL4ChBAq7h0E=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: rclone-conf
+      namespace: apps--backpan-syncer


### PR DESCRIPTION
This PR sets up the single container which runs the sync

- Requires privieges because is uses fuse file system
- Has secret for rclone so that it can access b2 (source in 1password)
- Has 2 PVC's - one for the primary data and the other for the sync cache

Currently it will just start a container, but I've connected and confirm the rclone mount works as does the rrr-watcher tool.

IF this setup is ok then I'd like to get this merged then do the syncing of disk (via manually connecting to the container) then I'll do another PR which will set the entry point to the `run.sh` script

Source for the Docker image is in https://github.com/metacpan/metacpan-backpan-syncer/