### PR TITLE
Add DataDog agent to the cluster

### DIFF
--- a/platform/datadog/datadog-agent.yaml
+++ b/platform/datadog/datadog-agent.yaml
@@ -1,0 +1,17 @@
+apiVersion: "datadoghq.com/v2alpha1"
+kind: "DatadogAgent"
+metadata:
+  name: "datadog"
+spec:
+  global:
+    site: "datadoghq.eu"
+    tags:
+      - "env:prod"
+    credentials:
+      apiSecret:
+        secretName: "datadog-secret"
+        keyName: "api-key"
+  features:
+    logCollection:
+      enabled: true
+      containerCollectAll: true

--- a/platform/datadog/kustomization.yaml
+++ b/platform/datadog/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./datadog-agent.yaml


### PR DESCRIPTION
Followed their instructions:

```
helm repo add datadog https://helm.datadoghq.com

helm install datadog-operator datadog/datadog-operator

kubectl create secret generic datadog-secret --from-literal api-key=PROVIEDED_BY_DATADOG_UI

vim code platform/datadog/datadog-agent.yaml (Content from DATADOG UI)

kubectl apply -k platform/datadog 
```
Now have their agent running and data from the cluster in DD