### PR TITLE
Anubis domain settings

### DIFF
--- a/apps/web/base/deployment.yaml
+++ b/apps/web/base/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: "true"
             - name: "OG_EXPIRY_TIME"
               value: "24h"
+            - name: "REDIRECT_DOMAINS"
+              value: "web.do.metacpan.org,metacpan.org,www.metacpan.org"
           resources:
             limits:
               cpu: 750m


### PR DESCRIPTION
Anubis intelligently picks the host for which it's running and proxies
traffic according to it. This works well, if you're pointing one host at
the service. We're pointing 3, as the hosts use Fastly for caching/DDoS
protection.

Updating the environment variable to include the domains should allow
Anubis to proxy all requests.
